### PR TITLE
Support timeouts and killing containers

### DIFF
--- a/config/orchestrator.json.in
+++ b/config/orchestrator.json.in
@@ -1,6 +1,7 @@
 {
   "name": "mignificient-orchestrator",
   "sharing-model": "sequential",
+  "timeout-check-interval-ms": 100,
   "ipc": {
     "backend": "iceoryx2",
     "buffer-config": {

--- a/executor/python/cli.py
+++ b/executor/python/cli.py
@@ -10,7 +10,7 @@ import mignificient
 if __name__ == "__main__":
 
     function_file = os.environ["FUNCTION_FILE"]
-    function_name = os.environ["FUNCTION_NAME"]
+    function_name = os.environ["FUNCTION_HANDLER"]
     container_name = os.environ["CONTAINER_NAME"]
 
     ipc_backend = os.environ["IPC_BACKEND"]

--- a/executor/src/executor_cpp.cpp
+++ b/executor/src/executor_cpp.cpp
@@ -14,7 +14,7 @@ typedef int (*fptr)(mignificient::Invocation);
 fptr load_function()
 {
   std::string function_file{std::getenv("FUNCTION_FILE")};
-  std::string function_name{std::getenv("FUNCTION_NAME")};
+  std::string function_name{std::getenv("FUNCTION_HANDLER")};
 
   void *handle = dlopen(function_file.c_str(), RTLD_NOW);
   if (handle == nullptr)

--- a/invoker/cli.cpp
+++ b/invoker/cli.cpp
@@ -82,7 +82,7 @@ void independent(const std::string& address, int iterations, int parallel_reques
               spdlog::error("Failed invocation! Result {}");
 
               if(response) {
-                spdlog::error("Status {} Body {}", drogon::to_string_view(result), response->getStatusCode(), response->body());
+                spdlog::error("Status {} Code {} Body {}", drogon::to_string_view(result), response->getStatusCode(), response->body());
               }
             } else {
               SPDLOG_DEBUG("Finished invocation. Result {} Body {}", drogon::to_string_view(result), response->body());
@@ -121,7 +121,7 @@ void independent(const std::string& address, int iterations, int parallel_reques
             spdlog::error("Failed invocation! Result {}");
 
             if(response) {
-              spdlog::error("Status {} Body {}", drogon::to_string_view(result), response->getStatusCode(), response->body());
+              spdlog::error("Status {} Code {} Body {}", drogon::to_string_view(result), response->getStatusCode(), response->body());
             }
           } else {
             spdlog::info("Finished invocation. Result {} Body {}", drogon::to_string_view(result), response->body());

--- a/orchestrator/include/mignificient/orchestrator/executor.hpp
+++ b/orchestrator/include/mignificient/orchestrator/executor.hpp
@@ -97,13 +97,14 @@ namespace mignificient { namespace orchestrator {
 
   class Executor {
   public:
-      Executor(const ipc::IPCConfig& ipc_config, const std::string& user, const std::string& function, float gpu_memory, GPUInstance& device, const std::optional<std::string>& ld_preload):
+      Executor(const ipc::IPCConfig& ipc_config, const std::string& user, const std::string& function, const std::string& function_handler, float gpu_memory, GPUInstance& device, const std::optional<std::string>& ld_preload):
         _ipc_config(ipc_config),
         _user(user),
         _gpu_memory(gpu_memory),
         _ld_preload(ld_preload),
         _pid(0),
         _function(function),
+        _function_handler(function_handler),
         _device(device)
       {}
 
@@ -140,6 +141,7 @@ namespace mignificient { namespace orchestrator {
       float _gpu_memory;
       pid_t _pid;
       std::string _function;
+      std::string _function_handler;
       GPUInstance& _device;
   };
 
@@ -149,11 +151,11 @@ namespace mignificient { namespace orchestrator {
 
     BareMetalExecutorCpp(
       const ipc::IPCConfig& ipc_config, const std::string& user_id, const std::string& function,
-      const std::string& function_path,
+      const std::string& function_handler, const std::string& function_path,
       float gpu_memory, GPUInstance& device, const Json::Value& config,
       std::optional<std::string> ld_preload
     ):
-      Executor(ipc_config, user_id, function, gpu_memory, device, ld_preload),
+      Executor(ipc_config, user_id, function, function_handler, gpu_memory, device, ld_preload),
       _function_path(function_path),
       _cpp_executor(config["cpp"].asString()),
       _gpuless_lib(config["gpuless-lib"].asString())
@@ -175,6 +177,7 @@ namespace mignificient { namespace orchestrator {
         const ipc::IPCConfig& ipc_config,
         const std::string& user_id,
         const std::string& function,
+        const std::string& function_handler,
         const std::string& function_path,
         const std::string& cuda_binary,
         const std::string& cubin_analysis,
@@ -183,7 +186,7 @@ namespace mignificient { namespace orchestrator {
         const Json::Value& config,
         std::optional<std::string> ld_preload
     ):
-      Executor(ipc_config, user_id, function, gpu_memory, device, ld_preload),
+      Executor(ipc_config, user_id, function, function_handler, gpu_memory, device, ld_preload),
       _function_path(function_path),
       _cuda_binary(cuda_binary),
       _cubin_analysis(cubin_analysis),
@@ -212,12 +215,13 @@ namespace mignificient { namespace orchestrator {
         const ipc::IPCConfig& ipc_config,
         const std::string& user_id,
         const std::string& function,
+        const std::string& function_handler,
         const std::string& function_path,
         float gpu_memory, GPUInstance& device,
         const Json::Value& config,
         const std::optional<std::string>& ld_preload
     ):
-      Executor(ipc_config, user_id, function, gpu_memory, device, ld_preload),
+      Executor(ipc_config, user_id, function, function_handler, gpu_memory, device, ld_preload),
       _function_path(function_path),
       _cpp_executor(config["cpp"].asString()),
       _gpuless_lib(config["gpuless-lib"].asString())

--- a/orchestrator/include/mignificient/orchestrator/executor.hpp
+++ b/orchestrator/include/mignificient/orchestrator/executor.hpp
@@ -37,6 +37,8 @@ namespace mignificient { namespace orchestrator {
 
     bool start(const ipc::IPCConfig& ipc_config, const std::string& user_id, GPUInstance& instance, bool poll_sleep, bool use_vmm, const Json::Value& config, int cpu_idx = -1);
 
+    pid_t pid() const { return _pid; }
+
   private:
     pid_t _pid;
   };

--- a/orchestrator/include/mignificient/orchestrator/invocation.hpp
+++ b/orchestrator/include/mignificient/orchestrator/invocation.hpp
@@ -74,6 +74,7 @@ namespace mignificient { namespace orchestrator {
 
       _input_payload = input_data["input-payload"].asString();
       _function_name = input_data["function"].asString();
+      _function_handler = input_data["function-handler"].asString();
       _container = input_data["container"].asString();
       _function_path = input_data["function-path"].asString();
       _user = input_data["user"].asString();
@@ -130,6 +131,11 @@ namespace mignificient { namespace orchestrator {
     const std::string& function_name() const
     {
       return _function_name;
+    }
+
+    const std::string& function_handler() const
+    {
+      return _function_handler;
     }
 
     const std::string& function_path() const
@@ -189,6 +195,7 @@ namespace mignificient { namespace orchestrator {
     std::optional<std::string> _ld_preload;
     std::string _input_payload;
     std::string _function_name;
+    std::string _function_handler;
     std::string _function_path;
     std::string _container;
     std::string _user;

--- a/orchestrator/include/mignificient/orchestrator/orchestrator.hpp
+++ b/orchestrator/include/mignificient/orchestrator/orchestrator.hpp
@@ -51,6 +51,10 @@ namespace mignificient { namespace orchestrator {
 
     int _client_id = 0;
     int _invoc_id = 0;
+    int _timeout_check_interval_ms = 100;
+
+    void _check_timeouts();
+    void _handle_admin_request(AdminRequest&& req);
 
     std::unordered_map<int, Client> clients;
 
@@ -92,6 +96,8 @@ namespace mignificient { namespace orchestrator {
       iox2::WaitSetAttachmentId<iox2::ServiceType::Ipc>,
       std::tuple<Client*, bool>
     > _waitset_mappings_v2;
+
+    std::optional<iox2::WaitSetGuard<iox2::ServiceType::Ipc>> _timeout_interval_guard;
 
     void _event_loop_v2();
     void _handle_http_v2();

--- a/orchestrator/include/mignificient/orchestrator/users.hpp
+++ b/orchestrator/include/mignificient/orchestrator/users.hpp
@@ -150,6 +150,7 @@ namespace mignificient { namespace orchestrator {
     {
       // Create a new client with configured buffer sizes
       std::string client_id = unique_client_name(username, fname);
+      const std::string& fhandler = invocation->function_handler();
 
       ipc::BufferConfig executor_buf;
       ipc::BufferConfig gpuless_buf;
@@ -192,7 +193,7 @@ namespace mignificient { namespace orchestrator {
       if(invocation->language() == Language::CPP) {
 
         auto exec = std::make_unique<BareMetalExecutorCpp>(
-          _ipc_config, client_id, fname, invocation->function_path(),
+          _ipc_config, client_id, fname, fhandler, invocation->function_path(),
           invocation->gpu_memory(), *selected_gpu, _config["bare-metal-executor"],
           invocation->ld_preload()
         );
@@ -202,7 +203,7 @@ namespace mignificient { namespace orchestrator {
       } else {
 
         auto exec = std::make_unique<BareMetalExecutorPython>(
-          _ipc_config, client_id, fname, invocation->function_path(),
+          _ipc_config, client_id, fname, fhandler, invocation->function_path(),
           invocation->cuda_binary(), invocation->cubin_analysis(),
           invocation->gpu_memory(), *selected_gpu,
           _config["bare-metal-executor"],

--- a/orchestrator/include/mignificient/orchestrator/users.hpp
+++ b/orchestrator/include/mignificient/orchestrator/users.hpp
@@ -61,7 +61,7 @@ namespace mignificient { namespace orchestrator {
 
             if (!client->is_busy() && !selected_gpu->is_busy()) {
               // Variant (A) - we have an idle container on idle GPU
-              spdlog::error("Using an existing client {} for user {}", client->id(), username);
+              spdlog::info("Using an existing client {} for user {}", client->id(), username);
               selected_client = client.get();
               fully_idle = true;
               break;
@@ -140,6 +140,67 @@ namespace mignificient { namespace orchestrator {
       for(auto& [username, clients] : _gpu_clients) {
         for(auto& client : clients) {
           func(client.get());
+        }
+      }
+    }
+
+    Client* find_client(const std::string& user, const std::string& id)
+    {
+      auto it = _gpu_clients.find(user);
+      if (it == _gpu_clients.end())
+        return nullptr;
+      for (auto& client : it->second) {
+        if (client->id() == id)
+          return client.get();
+      }
+      return nullptr;
+    }
+
+    void remove_client(const std::string& user, Client* target)
+    {
+      auto it = _gpu_clients.find(user);
+      if (it == _gpu_clients.end())
+        return;
+
+      auto& clients = it->second;
+      for (auto cit = clients.begin(); cit != clients.end(); ++cit) {
+        if (cit->get() == target) {
+          clients.erase(cit);
+          return;
+        }
+      }
+    }
+
+    template<typename F>
+    Json::Value list_containers(F status_fn)
+    {
+      Json::Value result(Json::objectValue);
+      for (auto& [username, clients] : _gpu_clients) {
+        Json::Value user_containers(Json::arrayValue);
+        for (auto& client : clients) {
+          Json::Value entry;
+          entry["id"] = client->id();
+          entry["function"] = client->fname();
+          entry["status"] = client->status_string();
+          entry["allocated"] = client->is_active();
+          user_containers.append(entry);
+        }
+        result[username] = user_containers;
+      }
+      return result;
+    }
+
+    template<typename F>
+    void check_timeouts(F on_timeout)
+    {
+      for (auto& [username, clients] : _gpu_clients) {
+        for (auto it = clients.begin(); it != clients.end(); ) {
+          if ((*it)->check_timeout()) {
+            on_timeout(it->get());
+            it = clients.erase(it);
+          } else {
+            ++it;
+          }
         }
       }
     }

--- a/orchestrator/src/executor.cpp
+++ b/orchestrator/src/executor.cpp
@@ -104,7 +104,7 @@ namespace mignificient { namespace orchestrator {
     char* argv[] = {const_cast<char*>(_cpp_executor.c_str()), NULL};
 
     std::string poll_type = fmt::format("POLL_TYPE={}", poll_sleep ? "wait" : "poll");
-    std::string fname = fmt::format("FUNCTION_NAME={}", _function);
+    std::string fname = fmt::format("FUNCTION_HANDLER={}", _function_handler);
     std::string cbinary = fmt::format("CUDA_BINARY={}", _function_path);
     std::string ffile = fmt::format("FUNCTION_FILE={}", _function_path);
 
@@ -180,7 +180,7 @@ namespace mignificient { namespace orchestrator {
     };
 
     std::string poll_type = fmt::format("POLL_TYPE={}", poll_sleep ? "wait" : "poll");
-    std::string fname = fmt::format("FUNCTION_NAME={}", _function);
+    std::string fname = fmt::format("FUNCTION_HANDLER={}", _function_handler);
     std::string cbinary = fmt::format("CUDA_BINARY={}", _cuda_binary);
     std::string ffile = fmt::format("FUNCTION_FILE={}", _function_path);
     std::string pythonpath = fmt::format("PYTHONPATH={}", _python_path);


### PR DESCRIPTION
This PR adds three new functionalities:
- HTTP request that lists active containers
- HTTP request that kills selected containers
- Detection of timeout for function and killing those containers

This required extending the main orchestrator loop to support both the repeated "wake up" as well as handling "admin requests" to support killing and listing containers.

Tested the following scenarios:
- Timeout function results in killing and correct attempts to reallocate later.
- Listing returns correct containers.
- Killing results in killing containers.
- Incorrect killing attempts are refuted.
- Works for both iceoryx v1 and v2.