### PR TITLE
Proper integration of memory swapping

### DIFF
--- a/executor/include/mignificient/executor/executor.hpp
+++ b/executor/include/mignificient/executor/executor.hpp
@@ -23,6 +23,8 @@
 namespace mignificient { namespace executor {
 
   struct SwapResult {
+    static constexpr const char* IOX2_TYPE_NAME = "SwapResult";
+
     double time_us;
     size_t memory_bytes;
     int status;

--- a/executor/include/mignificient/executor/executor.hpp
+++ b/executor/include/mignificient/executor/executor.hpp
@@ -22,6 +22,12 @@
 
 namespace mignificient { namespace executor {
 
+  struct SwapResult {
+    double time_us;
+    size_t memory_bytes;
+    int status;
+  };
+
   struct Invocation {
     // FIXME: replace with static array
     static constexpr int CAPACITY = 1 * 1024 * 1024;

--- a/executor/python/cli.py
+++ b/executor/python/cli.py
@@ -45,5 +45,5 @@ if __name__ == "__main__":
 
         size = func(mignificient.Invocation(runtime, invocation_data, runtime.result()))
 
-        runtime.finish(10)
+        runtime.finish(size)
 

--- a/executor/python/executor.cpp
+++ b/executor/python/executor.cpp
@@ -36,7 +36,7 @@ void define_mignificient_runtime(py::module& m)
       .def(
           "view_readable",
           [](mignificient::InvocationData& self) {
-            return py::memoryview::from_memory(self.data, sizeof(std::byte) * mignificient::executor::Invocation::CAPACITY);
+            return py::memoryview::from_memory(self.data, sizeof(std::byte) * self.size);
           }
       );
 

--- a/invoker/cli.cpp
+++ b/invoker/cli.cpp
@@ -85,7 +85,14 @@ void independent(const std::string& address, int iterations, int parallel_reques
                 spdlog::error("Status {} Code {} Body {}", drogon::to_string_view(result), response->getStatusCode(), response->body());
               }
             } else {
-              SPDLOG_DEBUG("Finished invocation. Result {} Body {}", drogon::to_string_view(result), response->body());
+              auto it = response->headers().find("x-mignificient-swap-in-time");
+              if(it != response->headers().end()) {
+                auto time = (*it).second;
+                auto bytes = response->headers().at("x-mignificient-swap-in-memory");
+                spdlog::info("Finished invocation with swap-in (time = {} us, size = {} bytes). Result {} Body {}", time, bytes, drogon::to_string_view(result), response->body());
+              } else {
+                spdlog::info("Finished invocation. Result {} Body {}", drogon::to_string_view(result), response->body());
+              }
             }
 
           }
@@ -124,7 +131,14 @@ void independent(const std::string& address, int iterations, int parallel_reques
               spdlog::error("Status {} Code {} Body {}", drogon::to_string_view(result), response->getStatusCode(), response->body());
             }
           } else {
-            spdlog::info("Finished invocation. Result {} Body {}", drogon::to_string_view(result), response->body());
+            auto it = response->headers().find("x-mignificient-swap-in-time");
+            if(it != response->headers().end()) {
+              auto time = (*it).second;
+              auto bytes = response->headers().at("x-mignificient-swap-in-memory");
+              spdlog::info("Finished invocation with swap-in (time = {} us, size = {} bytes). Result {} Body {}", time, bytes, drogon::to_string_view(result), response->body());
+            } else {
+              spdlog::info("Finished invocation. Result {} Body {}", drogon::to_string_view(result), response->body());
+            }
           }
 
         }

--- a/orchestrator/include/mignificient/orchestrator/executor.hpp
+++ b/orchestrator/include/mignificient/orchestrator/executor.hpp
@@ -29,7 +29,8 @@ namespace mignificient { namespace orchestrator {
     SWAP_IN = 5,
 
     REGISTER = 10,
-    SWAP_OFF_CONFIRM = 11
+    SWAP_OFF_CONFIRM = 11,
+    SWAP_IN_CONFIRM = 12
   };
 
   class GPUlessServer {

--- a/orchestrator/include/mignificient/orchestrator/http.hpp
+++ b/orchestrator/include/mignificient/orchestrator/http.hpp
@@ -21,7 +21,7 @@
 
 namespace mignificient { namespace orchestrator {
 
-  enum class AdminRequestType { LIST_CONTAINERS, KILL_CONTAINER };
+  enum class AdminRequestType { LIST_CONTAINERS, KILL_CONTAINER, SWAP_OFF, SWAP_IN };
 
   struct AdminRequest {
     AdminRequestType type;
@@ -192,11 +192,15 @@ namespace mignificient { namespace orchestrator {
       ADD_METHOD_TO(HTTPServer::invoke, "/invoke", drogon::Post);
       ADD_METHOD_TO(HTTPServer::containers, "/containers", drogon::Get);
       ADD_METHOD_TO(HTTPServer::kill_container, "/kill", drogon::Post);
+      ADD_METHOD_TO(HTTPServer::swap_off, "/swap-off", drogon::Post);
+      ADD_METHOD_TO(HTTPServer::swap_in, "/swap-in", drogon::Post);
       METHOD_LIST_END
 
       void invoke(const drogon::HttpRequestPtr& req, std::function<void(const drogon::HttpResponsePtr&)>&& callback);
       void containers(const drogon::HttpRequestPtr& req, std::function<void(const drogon::HttpResponsePtr&)>&& callback);
       void kill_container(const drogon::HttpRequestPtr& req, std::function<void(const drogon::HttpResponsePtr&)>&& callback);
+      void swap_off(const drogon::HttpRequestPtr& req, std::function<void(const drogon::HttpResponsePtr&)>&& callback);
+      void swap_in(const drogon::HttpRequestPtr& req, std::function<void(const drogon::HttpResponsePtr&)>&& callback);
 
       HTTPServer(Json::Value & config, HTTPTrigger& trigger);
       void run();

--- a/orchestrator/include/mignificient/orchestrator/invocation.hpp
+++ b/orchestrator/include/mignificient/orchestrator/invocation.hpp
@@ -2,12 +2,15 @@
 #define __MIGNIFICIENT_ORCHESTRATOR_INVOCATION_HPP__
 
 #include <chrono>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
 #include <drogon/HttpResponse.h>
 #include <drogon/HttpTypes.h>
 #include <spdlog/spdlog.h>
+
+#include <mignificient/executor/executor.hpp>
 
 namespace mignificient { namespace orchestrator {
 
@@ -113,6 +116,11 @@ namespace mignificient { namespace orchestrator {
       _http_callback(resp);
     }
 
+    void set_swap_in_stats(const executor::SwapResult& stats)
+    {
+      _swap_in_stats = stats;
+    }
+
     void respond(std::string_view response)
     {
       auto end = std::chrono::high_resolution_clock::now();
@@ -122,8 +130,12 @@ namespace mignificient { namespace orchestrator {
 
       // Zero-copy operation
       resp->setViewBody(response.begin(), response.size());
-      // This one works with default implementation
-      //resp->setBody(std::string{response.begin(), response.size()});
+
+      // Add swap-in stats headers if this invocation required a swap-in
+      if(_swap_in_stats.has_value()) {
+        resp->addHeader("X-MIGnificient-Swap-In-Time", std::to_string(_swap_in_stats->time_us));
+        resp->addHeader("X-MIGnificient-Swap-In-Memory", std::to_string(_swap_in_stats->memory_bytes));
+      }
 
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - _begin).count();
       SPDLOG_DEBUG("[Invoc] Responding to the HTTP request for invocation {} from user {} after {} ms", _uuid, _user, duration / 1000.0);
@@ -216,6 +228,7 @@ namespace mignificient { namespace orchestrator {
   private:
     std::function<void(const drogon::HttpResponsePtr&)> _http_callback;
 
+    std::optional<executor::SwapResult> _swap_in_stats;
     decltype(std::chrono::high_resolution_clock::now()) _begin;
     Language _function_language;
     std::string _cuda_binary;

--- a/orchestrator/src/client.cpp
+++ b/orchestrator/src/client.cpp
@@ -77,6 +77,17 @@ namespace mignificient { namespace orchestrator {
 
       gpuless_listener = gpuless_event_listen->listener_builder().create().value();
       gpuless_notifier = gpuless_event_notify->notifier_builder().create().value();
+
+      {
+        auto swap_result_service = node.service_builder(
+            iox2::ServiceName::create(fmt::format("{}.Orchestrator.Gpuless.SwapResult", id).c_str()).value())
+        .publish_subscribe<mignificient::executor::SwapResult>()
+        .max_publishers(1)
+        .max_subscribers(1)
+        .open_or_create().value();
+
+        gpuless_swap_recv = std::move(swap_result_service.subscriber_builder().create().value());
+      }
     }
 
   }

--- a/orchestrator/src/http.cpp
+++ b/orchestrator/src/http.cpp
@@ -59,6 +59,64 @@ namespace mignificient { namespace orchestrator {
     _trigger.trigger_admin(std::move(admin_req));
   }
 
+  void HTTPServer::swap_off(const drogon::HttpRequestPtr& req,
+              std::function<void(const drogon::HttpResponsePtr&)>&& callback)
+  {
+    auto body = req->getJsonObject();
+    if (!body || !body->isMember("container") || !body->isMember("user")) {
+      Json::Value error;
+      error["success"] = false;
+      error["error"] = "Missing 'user' or 'container' field in request body";
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
+      resp->setStatusCode(drogon::k400BadRequest);
+      callback(resp);
+      return;
+    }
+
+    AdminRequest admin_req;
+    admin_req.type = AdminRequestType::SWAP_OFF;
+    admin_req.user = (*body)["user"].asString();
+    admin_req.container = (*body)["container"].asString();
+    admin_req.respond = [callback](Json::Value result) {
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(result);
+      if (!result["success"].asBool()) {
+        resp->setStatusCode(result.isMember("not_found") ? drogon::k404NotFound : drogon::k400BadRequest);
+      }
+      callback(resp);
+    };
+
+    _trigger.trigger_admin(std::move(admin_req));
+  }
+
+  void HTTPServer::swap_in(const drogon::HttpRequestPtr& req,
+              std::function<void(const drogon::HttpResponsePtr&)>&& callback)
+  {
+    auto body = req->getJsonObject();
+    if (!body || !body->isMember("container") || !body->isMember("user")) {
+      Json::Value error;
+      error["success"] = false;
+      error["error"] = "Missing 'user' or 'container' field in request body";
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
+      resp->setStatusCode(drogon::k400BadRequest);
+      callback(resp);
+      return;
+    }
+
+    AdminRequest admin_req;
+    admin_req.type = AdminRequestType::SWAP_IN;
+    admin_req.user = (*body)["user"].asString();
+    admin_req.container = (*body)["container"].asString();
+    admin_req.respond = [callback](Json::Value result) {
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(result);
+      if (!result["success"].asBool()) {
+        resp->setStatusCode(result.isMember("not_found") ? drogon::k404NotFound : drogon::k400BadRequest);
+      }
+      callback(resp);
+    };
+
+    _trigger.trigger_admin(std::move(admin_req));
+  }
+
   HTTPServer::HTTPServer(Json::Value & config, HTTPTrigger& trigger):
     _trigger(trigger)
   {


### PR DESCRIPTION
We had an implementation of swapping in and swapping off for a long time. This PR adds a proper integration:
- Explicit HTTP methods.
- Verified swap-in of a lukewarm container during invocation.
- Printing out statistics and returning to the user.

We tested these scenarios:
- Explicit swap-off.
- Explicit swap-in.
- Swap-in during invocation.